### PR TITLE
fix bug

### DIFF
--- a/django_ltree/lookups.py
+++ b/django_ltree/lookups.py
@@ -9,8 +9,7 @@ class SimpleLookup(Lookup):
     def as_sql(self, compiler, connection):
         lhs, lhs_params = self.process_lhs(compiler, connection)
         rhs, rhs_params = self.process_rhs(compiler, connection)
-        params = lhs_params + rhs_params
-        return "{} {} {}".format(lhs, self.lookup_operator, rhs), params
+        return "{} {} {}".format(lhs, self.lookup_operator, rhs), [*lhs_params, *rhs_params]
 
 
 @PathField.register_lookup
@@ -20,9 +19,7 @@ class EqualLookup(Lookup):
     def as_sql(self, compiler, connection):
         lhs, lhs_params = self.process_lhs(compiler, connection)
         rhs, rhs_params = self.process_rhs(compiler, connection)
-        params = lhs_params + rhs_params
-
-        return "{} = {}".format(lhs, rhs), params
+        return "{} = {}".format(lhs, rhs), [*lhs_params, *rhs_params]
 
 
 @PathField.register_lookup


### PR DESCRIPTION
bugfix `TypeError: can only concatenate tuple (not "list") to tuple`

detail of the error:

```
File "/opt/virtual_env/mch/lib/python3.9/site-packages/django_ltree/lookups.py", line 12, in as_sql
    params = lhs_params + rhs_params
TypeError: can only concatenate tuple (not "list") to tuple
```

The code that triggered it

```
MyModel.objects.annotate(
        annotated_path=Subquery(
            MyOtherModel.objects.filter(id=OuterRef("related_id")).values("path")[:1],
            output_field=PathField(),
        )
    )
    .filter(scope_path__descendants=Value(PathValue("2"), output_field=PathField()))
    .values("scope_path")
```

The bug appears because `scope_path__descendants` yields a tuple as lhs value, whereas the `Value` expression yields a list as the rhs_value.