### PR TITLE
Automatic AppConfig discovery for support Django 3.2

### DIFF
--- a/django_ltree/__init__.py
+++ b/django_ltree/__init__.py
@@ -1,1 +1,4 @@
-default_app_config = 'django_ltree.apps.DjangoLtreeConfig'
+import django
+
+if django.VERSION < (3, 2):
+    default_app_config = 'django_ltree.apps.DjangoLtreeConfig'


### PR DESCRIPTION
https://docs.djangoproject.com/en/4.0/releases/3.2/#what-s-new-in-django-3-2

This fix the error or warning when trying to add `django_ltree` in the `INSTALLED_APPS` settings.

```
django.utils.deprecation.RemovedInDjango41Warning: 'django_ltree' defines default_app_config = 'django_ltree.apps.DjangoLtreeConfig'. Django now detects this configuration automatically. You can remove default_app_config.
```
