### PR TITLE
♻️ REFACTOR check_database_backend_is_postgres

### DIFF
--- a/django_ltree/checks.py
+++ b/django_ltree/checks.py
@@ -8,7 +8,7 @@ def check_database_backend_is_postgres(app_configs, **kwargs):
     errors = []
     valid_dbs = ["postgres", "postgis"]
 
-    if not any(d in settings.DATABASES["default"]["ENGINE"] for d in valid_dbs):
+    if "default" in settings.DATABASES and all(d not in settings.DATABASES["default"]["ENGINE"] for d in valid_dbs):
         errors.append(
             Warning(
                 "django_ltree needs postgres to support install the ltree extension.",


### PR DESCRIPTION
1. invert not any => all
2. ensure that settings.DATABASES has default set
 
## Why?

I use docker a lot. Sometimes I need to run commands like `docker exec -it <container_running django> python manage.py <some_command_that_does_not_need_database>` so I will get error messages like

```bash
File "/usr/local/lib/python3.8/dist-packages/django_ltree/checks.py", line 11, in check_database_backend_is_postgres
    if not any(d in settings.DATABASES["default"]["ENGINE"] for d in valid_dbs):
  File "/usr/local/lib/python3.8/dist-packages/django_ltree/checks.py", line 11, in <genexpr>
    if not any(d in settings.DATABASES["default"]["ENGINE"] for d in valid_dbs):
KeyError: 'default'
```

So I like to have the check_database_backend_is_postgres only to do so when there's actually a default database set.

On top of that, i follow [sourcery's](https://sourcery.ai/) recommendations to refactor any => all