### PR TITLE
fix path_field validation regex to match postgres documentation

### DIFF
--- a/django_ltree/fields.py
+++ b/django_ltree/fields.py
@@ -7,7 +7,7 @@ from django.forms.widgets import TextInput
 from collections.abc import Iterable
 
 path_label_validator = RegexValidator(
-    r"^(?P<root>[a-zA-Z][a-zA-Z0-9_]*|\d+)(?:\.[a-zA-Z0-9_]+)*$",
+    r"^(?P<root>[a-zA-Z0-9_-]+)(?:\.[a-zA-Z0-9_-]+)*$",
     "A label is a sequence of alphanumeric characters and underscores separated by dots.",
     "invalid",
 )

--- a/tests/test_path_field.py
+++ b/tests/test_path_field.py
@@ -1,0 +1,30 @@
+import pytest
+
+from django.core.exceptions import ValidationError
+from django_ltree.fields import PathValue
+
+from taxonomy.models import Taxonomy
+
+
+@pytest.mark.parametrize(["path", "valid"], [
+    ("00_00a", True),
+    ("00$00", False),
+    ("00000a.00000b", True),
+    ("00000a+00000b", False),
+])
+def test_path_field_validation(path, valid):
+    """Validating that the path field is valid."""
+    taxonomy = Taxonomy()
+    taxonomy.name='test'
+    taxonomy.path = PathValue(path)
+    if valid:
+        taxonomy.full_clean()
+    else:
+        with pytest.raises(ValidationError) as excinfo:
+            taxonomy.full_clean()
+
+        assert excinfo.value.message_dict == {'path': ['A label is a sequence of alphanumeric characters and underscores separated by dots.']}
+
+
+
+


### PR DESCRIPTION
In the postgres documentation, a label in a path is a sequence of alphanumeric characters and underscores. The regex validating the path value was not validating this. This commit fix this issue and add tests validating the regex.

Fix #29